### PR TITLE
WCAG 2.1: Support input attributes for dates and addresses

### DIFF
--- a/app/views/casa/components/date-input/README.md
+++ b/app/views/casa/components/date-input/README.md
@@ -23,6 +23,41 @@ casaGovukDateInput({
 })
 ```
 
+With configurable items:
+
+```nunjucks
+{% from "casa/components/date-input/macro.njk" import casaGovukDateInput %}
+
+casaGovukDateInput({
+  namePrefix: "dateOfBirth",
+  casaValue: formData.dateOfBirth,
+  casaErrors: formErrors,
+  items: [
+    {
+      autocomplete: "bday-day",
+      attributes: {
+        min: "1",
+        max: "31"
+      }
+    },
+    {
+      autocomplete: "bday-month",
+      attributes: {
+        min: "1",
+        max: "12"
+      }
+    },
+    {
+      autocomplete: "bday-year",
+      attributes: {
+        min: "1",
+        max: "9999"
+      }
+    }
+  ]
+})
+```
+
 ## Companion validation
 
 There is a companion validation rule - [`dateObject`](../../../../../docs/field-validation-rules.md#dateObject) - that you can use to ensure the dates are passed in correctly.

--- a/app/views/casa/components/date-input/template.njk
+++ b/app/views/casa/components/date-input/template.njk
@@ -20,26 +20,32 @@
   id: params.id if params.id else 'f-' + params.namePrefix,
   namePrefix: '',
   attributes: mergedAttributes,
-  items: [{
-    label: t('macros:dateInput.day'),
-    name: params.namePrefix + '[dd]',
-    id: 'f-' + params.namePrefix + '[dd]',
-    value: params.casaValue.dd,
-    classes: 'govuk-input--width-2 ' + (inputErrorClass if includes(fieldErrors[0].focusSuffix, '[dd]') or not hasSuffixHighlights)
-  }, {
-    label: t('macros:dateInput.month'),
-    name: params.namePrefix + '[mm]',
-    id: 'f-' + params.namePrefix + '[mm]',
-    value: params.casaValue.mm,
-    classes: 'govuk-input--width-2 ' + (inputErrorClass if includes(fieldErrors[0].focusSuffix, '[mm]') or not hasSuffixHighlights),
-    attributes: attributes_mm
-  }, {
-    label: t('macros:dateInput.year'),
-    name: params.namePrefix + '[yyyy]',
-    id: 'f-' + params.namePrefix + '[yyyy]',
-    value: params.casaValue.yyyy,
-    classes: 'govuk-input--width-4 ' + (inputErrorClass if includes(fieldErrors[0].focusSuffix, '[yyyy]') or not hasSuffixHighlights)
-  }],
+  items: [
+    mergeObjectsDeep({
+      id: 'f-' + params.namePrefix + '[dd]',
+      name: params.namePrefix + '[dd]',
+      value: params.casaValue.dd
+    }, params.items[0] if params.items[0] else {}, {
+      label: t('macros:dateInput.day'),
+      classes: 'govuk-input--width-2 ' + (inputErrorClass if includes(fieldErrors[0].focusSuffix, '[dd]') or not hasSuffixHighlights)
+    }),
+    mergeObjectsDeep({
+      id: 'f-' + params.namePrefix + '[mm]',
+      name: params.namePrefix + '[mm]',
+      value: params.casaValue.mm
+    }, params.items[1] if params.items[1] else {}, {
+      label: t('macros:dateInput.month'),
+      classes: 'govuk-input--width-2 ' + (inputErrorClass if includes(fieldErrors[0].focusSuffix, '[mm]') or not hasSuffixHighlights)
+    }),
+    mergeObjectsDeep({
+      id: 'f-' + params.namePrefix + '[yyyy]',
+      name: params.namePrefix + '[yyyy]',
+      value: params.casaValue.yyyy
+    }, params.items[2] if params.items[2] else {}, {
+      label: t('macros:dateInput.year'),
+      classes: 'govuk-input--width-4 ' + (inputErrorClass if includes(fieldErrors[0].focusSuffix, '[yyyy]') or not hasSuffixHighlights)
+    })
+  ],
   errorMessage: {
     text: t(params.casaErrors[params.namePrefix][0].inline)
   } if params.casaErrors[params.namePrefix] else null

--- a/app/views/casa/components/postal-address-object/README.md
+++ b/app/views/casa/components/postal-address-object/README.md
@@ -15,7 +15,34 @@ Basic example:
 {{ casaPostalAddressObject({
   name: 'address',
   value: formData.address,
-  casaErrors: formErrors,
+  casaErrors: formErrors
+}) }}
+```
+
+With configurable items:
+
+```nunjucks
+{% from "casa/components/postal-address-object/macro.njk" import casaPostalAddressObject %}
+
+{{ casaPostalAddressObject({
+  name: 'address',
+  value: formData.address,
+  address1: {
+    autocomplete: 'address-line1'
+  },
+  address2: {
+    autocomplete: 'address-line2'
+  },
+  address3: {
+    autocomplete: 'address-level2'
+  },
+  address4: {
+    autocomplete: 'address-level1'
+  },
+  postcode: {
+    autocomplete: 'postal-code'
+  },
+  casaErrors: formErrors
 }) }}
 ```
 

--- a/app/views/casa/components/postal-address-object/template.njk
+++ b/app/views/casa/components/postal-address-object/template.njk
@@ -14,36 +14,39 @@
     {% if fieldAddress1Errors %}
       {% set fieldAttributes = mergeObjects(fieldAttributes, {'data-validation': {fn: params.name + '[address1]', va: fieldAddress1Errors[0].validator} | dump}) %}
     {% endif %}
-    {{ govukInput({
+
+    {{ govukInput(mergeObjectsDeep({
+      id: 'f-' + params.name + '[address1]',
+      name: params.name + '[address1]',
+      value: params.value.address1
+    }, params.address1 if params.address1 else {}, {
       label: {
         html: t('macros:postalAddressObject.address1')
       },
-      id: 'f-' + params.name + '[address1]',
-      name: params.name + '[address1]',
-      value: params.value.address1,
       attributes: fieldAttributes,
       errorMessage: {
         text: t(fieldAddress1Errors[0].inline)
       } if fieldAddress1Errors else null
-    }) }}
+    })) }}
 
     {# Line 2 #}
     {% set fieldAttributes = {} %}
     {% if fieldAddress2Errors %}
       {% set fieldAttributes = mergeObjects(fieldAttributes, {'data-validation': {fn: params.name + '[address2]', va: fieldAddress2Errors[0].validator} | dump}) %}
     {% endif %}
-    {{ govukInput({
+    {{ govukInput(mergeObjectsDeep({
+      id: 'f-' + params.name + '[address2]',
+      name: params.name + '[address2]',
+      value: params.value.address2
+    }, params.address2 if params.address2 else {}, {
       label: {
         html: t('macros:postalAddressObject.address2')
       },
-      id: 'f-' + params.name + '[address2]',
-      name: params.name + '[address2]',
-      value: params.value.address2,
       attributes: fieldAttributes,
       errorMessage: {
         text: t(fieldAddress2Errors[0].inline)
       } if fieldAddress2Errors else null
-    }) }}
+    })) }}
   </div>
 
   {# Town #}
@@ -52,19 +55,20 @@
   {% if fieldErrors %}
     {% set fieldAttributes = mergeObjects(fieldAttributes, {'data-validation': {fn: params.name + '[address3]', va: fieldErrors[0].validator} | dump}) %}
   {% endif %}
-  {{ govukInput({
-    label: {
-      html: t('macros:postalAddressObject.address3')
-    },
+  {{ govukInput(mergeObjectsDeep({
     id: 'f-' + params.name + '[address3]',
     name: params.name + '[address3]',
     value: params.value.address3,
-    classes: "govuk-!-width-two-thirds",
+    classes: "govuk-!-width-two-thirds"
+  }, params.address3 if params.address3 else {}, {
+    label: {
+      html: t('macros:postalAddressObject.address3')
+    },
     attributes: fieldAttributes,
     errorMessage: {
       text: t(fieldErrors[0].inline)
     } if fieldErrors else null
-  }) }}
+  })) }}
 
   {# County #}
   {% set fieldErrors = params.casaErrors[params.name+"[address4]"] %}
@@ -72,19 +76,20 @@
   {% if fieldErrors %}
     {% set fieldAttributes = mergeObjects(fieldAttributes, {'data-validation': {fn: params.name + '[address4]', va: fieldErrors[0].validator} | dump}) %}
   {% endif %}
-  {{ govukInput({
-    label: {
-      html: t('macros:postalAddressObject.address4')
-    },
+  {{ govukInput(mergeObjectsDeep({
     id: 'f-' + params.name + '[address4]',
     name: params.name + '[address4]',
     value: params.value.address4,
-    classes: "govuk-!-width-two-thirds",
+    classes: "govuk-!-width-two-thirds"
+  }, params.address4 if params.address4 else {}, {
+    label: {
+      html: t('macros:postalAddressObject.address4')
+    },
     attributes: fieldAttributes,
     errorMessage: {
       text: t(fieldErrors[0].inline)
     } if fieldErrors else null
-  }) }}
+  })) }}
 
   {# Postcode #}
   {% set fieldErrors = params.casaErrors[params.name+"[postcode]"] %}
@@ -92,17 +97,18 @@
   {% if fieldErrors %}
     {% set fieldAttributes = mergeObjects(fieldAttributes, {'data-validation': {fn: params.name + '[postcode]', va: fieldErrors[0].validator} | dump}) %}
   {% endif %}
-  {{ govukInput({
-    label: {
-      html: t('macros:postalAddressObject.postcode')
-    },
+  {{ govukInput(mergeObjectsDeep({
     id: 'f-' + params.name + '[postcode]',
     name: params.name + '[postcode]',
     value: params.value.postcode,
-    classes: "govuk-input--width-10",
+    classes: "govuk-input--width-10"
+  }, params.postcode if params.postcode else {}, {
+    label: {
+      html: t('macros:postalAddressObject.postcode')
+    },
     attributes: fieldAttributes,
     errorMessage: {
       text: t(fieldErrors[0].inline)
     } if fieldErrors else null
-  }) }}
+  })) }}
 {% endcall %}


### PR DESCRIPTION
This commits prepares us for WCAG 2.1 **Input Purposes for User Interface Components**
https://www.w3.org/TR/WCAG21/#input-purposes

### Each date input can now have customisable params
Using the `items[]` array as we're extending `govukDateInput()`

```js
{{ casaGovukDateInput({
  items: [
    {
      autocomplete: "bday-day",
      attributes: {
        min: "1",
        max: "31"
      }
    },
    {
      autocomplete: "bday-month",
      attributes: {
        min: "1",
        max: "12"
      }
    },
    {
      autocomplete: "bday-year",
      attributes: {
        min: "1",
        max: "9999"
      }
    }
}) }}
```

### Each address line can also do the same

```js
{{ casaPostalAddressObject({
  address1: {
    autocomplete: 'address-line1'
  },
  address2: {
    autocomplete: 'address-line2'
  },
  address3: {
    autocomplete: 'address-level2'
  },
  address4: {
    autocomplete: 'address-level1'
  },
  postcode: {
    autocomplete: 'postal-code'
  }
}) }}
```