### PR TITLE
feat: adding Strict-Transport-Security header and fixing variable name

### DIFF
--- a/app/middleware/headers.js
+++ b/app/middleware/headers.js
@@ -3,7 +3,7 @@
  */
 const isStaticAsset = /.*\.(js|jpe?g|css|png|svg|woff2?|eot|ttf|otf)/;
 const isIE8 = /MSIE\s*8/i;
-const oneDay = 86400000;
+const oneHundredDaysInSeconds = 86400000;
 
 /**
  * Setup middleware.
@@ -59,6 +59,7 @@ module.exports = function mwHeaders(app, cspConfig, disabledHeadersConfig) {
     'X-XSS-Protection': '1; mode=block',
     'X-Frame-Options': 'DENY',
     'Content-Security-Policy': cspDirectives.join('; '),
+    'Strict-Transport-Security': `max-age=${oneHundredDaysInSeconds}`,
   };
 
   /**
@@ -83,7 +84,7 @@ module.exports = function mwHeaders(app, cspConfig, disabledHeadersConfig) {
     if (isStaticAsset.test(req.url)) {
       headers['Cache-Control'] = 'public';
       headers.Pragma = 'cache';
-      headers.Expires = new Date(Date.now() + oneDay).toUTCString();
+      headers.Expires = new Date(Date.now() + oneHundredDaysInSeconds).toUTCString();
     } else {
       headers['Cache-Control'] = 'no-cache, no-store, must-revalidate, private';
       headers.Pragma = 'no-cache';

--- a/test/unit/middleware/headersTests.js
+++ b/test/unit/middleware/headersTests.js
@@ -62,6 +62,7 @@ describe('Middleware: headers', () => {
       expect(headers).to.have.property('x-content-type-options');
       expect(headers).to.have.property('x-xss-protection');
       expect(headers).to.have.property('x-frame-options');
+      expect(headers).to.have.property('strict-transport-security');
       done();
     });
   });


### PR DESCRIPTION
After an internal thing, it was flagged this should be turned on.

There is a couple of other options, but I figured this made more sense.

https://helmetjs.github.io/docs/hsts/

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

Also unless my maths is wrong, 86400000 is not one day.

Signed-off-by: Colin Oakley <colin@htmlandbacon.com>