### PR TITLE
feat: Adding ability to set the text of a button in a journey

### DIFF
--- a/views/casa/components/journey-form/README.md
+++ b/views/casa/components/journey-form/README.md
@@ -51,4 +51,4 @@ Note that the submit button is configured to prevent double-clicks and avoid dup
 | `inEditMode` | boolean | No | Toggle edit-mode of the form (available to page templates using default GET/POST handlers via the local `inEditMode` variable) |
 | `editOriginUrl` | string | No | Absolute URL to the page from which the edit request came (defaults to `review`) (available to user's templates using default GET/POST handlers via the local `editOriginUrl` variable) |
 | `buttonBarHidden` | boolean | No | Toggle the rendering of the bar containing the "Continue" button and "Cancel" link.Useful if you want to render your own buttons |
-| `buttonText` | string | No | Overrides default button text i.e Save changes |
+| `buttonText` | string | No | Overrides default button text i.e Save changes. If you need to retain the save changes switch you will need to add this logic |

--- a/views/casa/components/journey-form/README.md
+++ b/views/casa/components/journey-form/README.md
@@ -51,3 +51,4 @@ Note that the submit button is configured to prevent double-clicks and avoid dup
 | `inEditMode` | boolean | No | Toggle edit-mode of the form (available to page templates using default GET/POST handlers via the local `inEditMode` variable) |
 | `editOriginUrl` | string | No | Absolute URL to the page from which the edit request came (defaults to `review`) (available to user's templates using default GET/POST handlers via the local `editOriginUrl` variable) |
 | `buttonBarHidden` | boolean | No | Toggle the rendering of the bar containing the "Continue" button and "Cancel" link.Useful if you want to render your own buttons |
+| `buttonText` | string | No | Overrides default button text i.e Save changes |

--- a/views/casa/components/journey-form/template.njk
+++ b/views/casa/components/journey-form/template.njk
@@ -14,7 +14,7 @@
         attributes: {
           id: 'continue-button'
         },
-        text: t('common:form.buttons.saveChanges.label') if params.inEditMode else t('common:form.buttons.continue.label'),
+        text: params.buttonText if params.buttonText else (t('common:form.buttons.saveChanges.label') if params.inEditMode else t('common:form.buttons.continue.label')),
         preventDoubleClick: true
       }) }}
 


### PR DESCRIPTION
I noticed on a team I was on they had rolled a number of versions of this component.

This adds the ability to pass in a buttonText param and override it if required.