### PR TITLE
fix: Update e-mail validation

### DIFF
--- a/lib/validation/rules/email.js
+++ b/lib/validation/rules/email.js
@@ -9,11 +9,11 @@
  * @param  {string} value Email address
  * @return {Promise} Promise
  */
-function email(value) {
-  const emailRegex = /^[^@\s]+@[^@\s.]+\.[^@\s]+$/;
-  const valid = String(value).match(emailRegex);
 
-  return valid ? Promise.resolve() : Promise.reject(this.errorMsg || {
+const { isEmail } = require('validator');
+
+function email(value) {
+  return isEmail(value) ? Promise.resolve() : Promise.reject(this.errorMsg || {
     inline: 'validation:rule.email.inline',
     summary: 'validation:rule.email.summary',
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3414,8 +3414,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3433,13 +3432,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3452,18 +3449,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3566,8 +3560,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3577,7 +3570,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3590,20 +3582,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3620,7 +3609,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3693,8 +3681,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3704,7 +3691,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3780,8 +3766,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3811,7 +3796,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3829,7 +3813,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3868,13 +3851,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -8672,6 +8653,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "moment": "2.24.0",
     "nunjucks": "3.2.0",
     "object-resolve-path": "1.1.1",
-    "uid-safe": "2.1.5"
+    "uid-safe": "2.1.5",
+    "validator": "^11.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "8.1.0",

--- a/test/unit/lib/validation/rules/email.test.js
+++ b/test/unit/lib/validation/rules/email.test.js
@@ -19,10 +19,9 @@ describe('Validation rule: email', () => {
 
   it('should reject for invalid emails', () => {
     const queue = [];
-
     queue.push(expect(email('invalid@domain@domain.net')).to.be.rejected);
     queue.push(expect(email('invalid')).to.be.rejected);
-
+    queue.push(expect(email('cats@cats.co.')).to.be.rejected);
     return Promise.all(queue);
   });
 


### PR DESCRIPTION
E-mail validation currently fails with a test@test.co. example. This has been updated to use an external library (https://www.npmjs.com/package/validator)